### PR TITLE
[FE] [FIX] prevent saved filter with same name

### DIFF
--- a/packages/backend/src/routes/visitorProfile.ts
+++ b/packages/backend/src/routes/visitorProfile.ts
@@ -208,6 +208,12 @@ router.post('/filter', async (req, res) => {
         .send('Reached the maximum amount of saved filters.');
     }
 
+    if (savedFilters.some((savedFilter) =>
+      savedFilter.filterName === filterName)) {
+      return res.status(203)
+        .send('Filter with that name already exists.');
+    }
+
     const profileDetails = await addSavedFilter(userID, filter);
     return res.status(200)
       .send(profileDetails.savedFilter);

--- a/packages/visitorWeb/src/components/Filter/Filter.tsx
+++ b/packages/visitorWeb/src/components/Filter/Filter.tsx
@@ -272,6 +272,13 @@ const Filter = (props: FilterProps) => {
       return;
     }
 
+    if (savedFilters.some((savedFilter) => savedFilter.filterName === filter.filterName)) {
+      setChangeStatus("failed");
+      setChangeStatusMsg(t('components.Filter.save-filter-failure'));
+      setNewFilterName("");
+      return;
+    }
+
     addSavedFilter(userToken, filter).then((res) => {
       if (!res || !filter.filterName || res.status == 500) {
         setChangeStatus("failed");


### PR DESCRIPTION
### 🛠 Changes being made

Previously, visitors could add another saved filter with the same name as another saved filter, even if there limit was reached.

### 🏎 PR checklist

1. Read the ticket
- [ ] Read the related ticket on Jira and understand the requirements for this ticket. In case anything is unclear, ask the ticket creator or ticket executor.
2. Matching PR description
- [ ] Check that the PR description on GitHub is aligned with the ticket description on Jira.
3. Review the changes on GitHub
- [ ] is the current version of the destination branch (mostly main) merged into the PR branch?
- [ ] does it fulfill the definition of done for the ticket?
- [ ] were the tests adjusted or extended for the changed behavior?
- [ ] was the documentation adjusted or extended for changed behavior?
- [ ] does it align with the team code guidelines?
- [ ] check readability of code - is it easy to understand what is happening in the code snippets?
- [ ] proper naming
- [ ] is it logical?
- [ ] are there any performance issues?
- [ ] could it be improved / simplified?
4. Execute locally / in testing environment
- [ ] Execute the code locally and check if there are any issues. Test whether the new behavior from the ticket acts as expected. Try to think of edge cases and test them.
5. Run tests
- [ ] Run the tests locally and check that all of them succeed.
6. Linting & Formatting
- [ ] Check that the changes didn’t cause any linting or formatting warnings of errors.
7. Submit Feedback
- [ ] Approve if all of the following points fulfilled:
   - all previous steps did not reveal any issues
   - there are no open comments on the PR

- [ ] otherwise, request changes with specific comments (constructive) on what to change!
